### PR TITLE
Additional HTTP label styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## &lt;http-method-label&gt;
 
-A HTTP method name display label for lists.
+An HTTP method name display label for lists.
 
 ```html
 <http-method-label method="get"></http-method-label>
@@ -19,7 +19,8 @@ A HTTP method name display label for lists.
 ## Usage
 
 ### Installation
-```
+
+```sh
 npm install @api-components/http-method-label --save
 ```
 
@@ -69,6 +70,7 @@ npm start
 ```
 
 ### Running the tests
+
 ```sh
 npm test
 ```

--- a/src/CommonStyles.js
+++ b/src/CommonStyles.js
@@ -18,7 +18,9 @@ export const labelCommon = css`
   border-radius: var(--http-method-label-border-radius, 3px);
   font-weight: var(--http-method-label-font-weigth, 400);
   font: inherit;
-  font-size: inherit;
+  font-size: var(--http-method-label-font-size, inherit);
+  min-width: var(--http-method-label-min-width, inherit);
+  text-align: var(--http-method-label-text-align, inherit);
 `;
 
 export const labelGet = css`


### PR DESCRIPTION
Add `--http-method-label-font-size`, `--http-method-label-min-width`, `--http-method-label-text-align` variables to allow more control over the styling of HTTP labels. These variables make it possible to unify the size of the HTTP labels to eliminate text shift inside API URL (see PR in api-method-documentation) and align the text inside the API navigation.

See attached screenshots with modified look.
![image](https://user-images.githubusercontent.com/6103913/110301084-b930aa00-8008-11eb-89ae-be0412c34ee7.png)
![image](https://user-images.githubusercontent.com/6103913/110301180-d36a8800-8008-11eb-90d1-86e62298a754.png)

